### PR TITLE
Fix bug fire sprinkler drop affect on story acces

### DIFF
--- a/fn_preprocessing.m
+++ b/fn_preprocessing.m
@@ -44,7 +44,7 @@ fnc_filters.red_tag = comp_ds_table.safety_class > 0;
 fnc_filters.fire_building = comp_ds_table.system == 9 & strcmp(string(comp_ds_table.service_location),'building') & comp_ds_table.impairs_system_operation;
 
 % fire suppresion damage that affects each tenant unit
-fnc_filters.fire_drops = comp_ds_table.subsystem_id == 23;
+fnc_filters.fire_drops = comp_ds_table.subsystem_id == 23 & comp_ds_table.impairs_system_operation;
 
 % Hazardous materials
 fnc_filters.global_hazardous_material = comp_ds_table.global_hazardous_material;


### PR DESCRIPTION
Was not correctly filtering fire sprinkler drops by what types of damage
actually affected fire system operations (e.g., was counting damage
state 1 as affecting operation when only damage staet 2 was slated)